### PR TITLE
Fix Category Formatting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,8 +9,9 @@ import './App.scss';
 
 const formatCategoryName = (category: string) => {
 	const formatted = category
+		// Insert space before capital letters, g indicates a "global" search, so all instances are replaced.
+		// All incoming data should be camelCase, so this should work. 
 		.replace(/([A-Z])/g, ' $1').trim()
-		.replace(/^./, (str) => str.toUpperCase());
 	return formatted;
 };
 

--- a/src/components/GalleryCategoryFilter/GalleryCategoryFilter.scss
+++ b/src/components/GalleryCategoryFilter/GalleryCategoryFilter.scss
@@ -33,6 +33,7 @@
 			font-size: 16px;
 			font-weight: 500;
 			padding: 8px 12px;
+			text-transform: capitalize;
 
 			@include tablet {
 				font-size: 20px;


### PR DESCRIPTION
- Remove capitalize regex function from **formatCategoryName** function in App.tsx
- Replace with CSS text-transform: capitalize on Category item in GalleryCategoryFilter.scss
- Add comment to regex in **formatCategoryName** function for better documentation.